### PR TITLE
Tooltip: Update background color to correct gray

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -529,7 +529,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "station.catalog/tooltip@0.0.4": {
+    "station.catalog/tooltip@0.0.5": {
         "files": [
             {
                 "name": "Tooltip.tsx",

--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ Catalog's components are available on [bit.dev](https://bit.dev/station/catalog)
 yarn add @bit/station.catalog.colors
 ```
 
-#### Requirements
+## Requirements
+#### Toolchain
 - `nvm` (`wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash` to install)
 - `npm` >= 6.13.7
 - `node` >= 13.11.0
 - `yarn` ~= latest
 
-use `nvm i` to use the correct version of `node` and `npm`
+You can use `nvm i` to use the correct version of `node` and `npm` (or Volta as well).
+
+#### Bit CLI
+Install `bit` CLI globally (for publishing and such): `brew install bit` or `yarn global add bit-bin`
+
+⚠️ Make sure you're logged in to use `bit` ! Do so with: `bit login`
+
+Request an invit if you don't have any yet.
+
 ## Setup
 As usual:
 ```shell script

--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
     "gen:icons": "ts-node --transpile-only scripts/generate-icons.ts",
     "gen:images": "node --experimental-modules scripts/genIconsModules.mjs",
     "chromatic": "chromatic --project-token=q65anlqcdyq"
+  },
+  "volta": {
+    "node": "13.11.0"
   }
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
-import React, {ReactNode} from 'react';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
-import {createUseStyles} from 'react-jss';
+import { createUseStyles } from 'react-jss';
 import Colors from '../Colors';
 import {TooltipStyles, TooltipPositions} from './index';
 
@@ -74,7 +74,7 @@ const useStyles = createUseStyles({
     ],
     display: 'flex',
     alignItems: 'center',
-    backgroundColor: (styles: TooltipStyles) => styles?.container?.color || Colors.lightSecondaryHoverBackgroundColor,
+    backgroundColor: (styles: TooltipStyles) => styles?.container?.color || Colors.lightSecondaryBackgroundColor,
     borderRadius: (styles: TooltipStyles) => styles?.container?.radius || 3,
     opacity: 0,
     transitionDuration: (styles: TooltipStyles) => styles?.exitDuration || 100,


### PR DESCRIPTION
## What & How
This PR updates the tooltip's background color to match the proposed design.

It is just a small `css` change.

## Test
Compare the `Tooltip` storybook and its [Zeplin usages here](https://app.zeplin.io/project/5e4abc35ca586dba0175bd34/styleguide/components?coid=5ece6ebe1d685e4847d4518a).