### PR TITLE
[ETF-867] Change max-width of account field in list-item

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -460,7 +460,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "station.catalog/list-item@0.0.28": {
+    "station.catalog/list-item@0.0.29": {
         "files": [
             {
                 "name": "ListItem.tsx",

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -119,7 +119,7 @@ const useStyles = (isRecent: boolean) =>
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
-      maxWidth: '70%',
+      maxWidth: '100%',
       '&>a': {
         fontSize: 10,
         fontWeight: 'normal',

--- a/src/stories/ListItem.story.tsx
+++ b/src/stories/ListItem.story.tsx
@@ -123,7 +123,7 @@ storiesOf('Components|ListItem', module)
         appIconUrl={text('appIconUrl', 'https://assets.getstation.com/apps-logos/slack.png')}
         title={text('title', 'Julien B')}
         subtitle={text('appName', 'Slack DM')}
-        account={'Station'}
+        account={text('account', 'Station')}
         type={select('type', types, types.tab)}
         url={'https://google.com/'}
         onClick={e => action('onListItemClicked')(e)}


### PR DESCRIPTION
[Linear issue link](https://linear.app/getstation/issue/ETF-867/the-google-drive-account-name-is-cut-when-displaying-the-results-after)